### PR TITLE
Fix Header and Footer Character Links

### DIFF
--- a/routes/characters.js
+++ b/routes/characters.js
@@ -62,6 +62,17 @@ router.get("/characters/:id", middleware.isLoggedIn, (req, res) => {
     });
 });
 
+// GET Character Redirect
+router.get("/characters/redirect/current", middleware.isLoggedIn, (req, res) => {
+    Character.findOne({user: req.user._id}, function(err, foundCharacter) {
+        if (err) {
+            console.log(err);
+        } else {
+            res.redirect("/characters/" + foundCharacter._id);
+        }
+    });
+});
+
 // GET Edit Character
 router.get("/characters/:id/edit", middleware.checkCharacterOwnership, (req, res) => {
     Character.findById(req.params.id, function(err, foundCharacter) {

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -10,7 +10,7 @@
                         <ul class="list-unstyled text-center m-0">
 
                             <!-- Pages -->
-                            <li><a class="textsize-1 textcolor-white texthover-black text-decoration-none" href="/character">character</a></li>
+                            <li><a class="textsize-1 textcolor-white texthover-black text-decoration-none" href="/characters/redirect/current">character</a></li>
                             <li><a class="textsize-1 textcolor-white texthover-black text-decoration-none" href="/help">help</a></li>
                             <li><a class="textsize-1 textcolor-white texthover-black text-decoration-none" href="/logout">log out</a></li>
                             

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -9,7 +9,7 @@
                 <div class="container px-3">
 
                   <!-- Navbar Brand -->
-                  <a class="navbar-brand" href="/character"><h1 class="display-3 texthover-black">rpu</h1></a>
+                  <a class="navbar-brand" href="/characters/redirect/current"><h1 class="display-3 texthover-black">rpu</h1></a>
 
                   <!-- Nav Links -->
                   <div class="navbar-nav flex-row float-right">

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -13,7 +13,7 @@
 
                   <!-- Nav Links -->
                   <div class="navbar-nav flex-row float-right">
-                        <a class="nav-link fs-3 ps-3 pe-3" href="/character"><i class="fas fa-user textcolor-white texthover-black" data-bs-toggle="tooltip" data-bs-placement="bottom" title="character"></i></a>
+                        <a class="nav-link fs-3 ps-3 pe-3" href="/characters/redirect/current"><i class="fas fa-user textcolor-white texthover-black" data-bs-toggle="tooltip" data-bs-placement="bottom" title="character"></i></a>
                         <a class="nav-link fs-3 ps-3 pe-3" href="/help"><i class="fas fa-info-circle textcolor-white texthover-black" data-bs-toggle="tooltip" data-bs-placement="bottom" title="help"></i></a>
                         <a class="nav-link fs-3 ps-3" href="/logout"><i class="fas fa-sign-out-alt textcolor-white texthover-black" data-bs-toggle="tooltip" data-bs-placement="bottom" title="log out"></i></a>
                   </div>


### PR DESCRIPTION
Adds a new Redirect Character GET route that redirects to the Character GET route passing along the character id found by searching characters for the user id of the currently authenticated user. The Show Character View links in the Header and Footer partials call this route. This fixes the issue of users viewing pages that do not embed their character's id and trying to navigate back to their character resulting in an error.